### PR TITLE
Read wkhtmltopdf command from env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 WORK_DIR=target/work_dir
 RUST_LOG=pdf_generator=info
+WKHTMLTOPDF_CMD=wkhtmltopdf
+


### PR DESCRIPTION
wkhtmltopdf has a history of patchs. (More at: https://wkhtmltopdf.org/status.html)

This commit makes easy to change wkhtmltopdf's path by exporting WKHTMLTOPDF_CMD to wherever you need.
